### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.parley.json
+++ b/org.kde.parley.json
@@ -14,6 +14,14 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include",
+        "/mkspecs",
+        "/share/doc"
+    ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
     "modules": [
         {
             "name": "kdeedu-data",


### PR DESCRIPTION
The installed size reduced from 309.0 MB to 295.3 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.